### PR TITLE
FEATURE - RSS통해 데이터 불러오도록 구현

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
     kotlin("jvm") version "1.7.22"
     kotlin("plugin.spring") version "1.7.22"
+    kotlin("plugin.jpa") version "1.4.31"
 }
 
 group = "com.colecto"
@@ -28,6 +29,9 @@ dependencies {
     implementation("org.redisson:redisson:3.20.1")
     implementation("org.flywaydb:flyway-core:9.17.0")
     implementation("org.flywaydb:flyway-mysql:9.17.0")
+
+    implementation("com.squareup.okhttp3:okhttp:4.11.0")
+    implementation("org.jsoup:jsoup:1.16.1")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/server/src/main/kotlin/com/colecto/colecto/ColectoApplication.kt
+++ b/server/src/main/kotlin/com/colecto/colecto/ColectoApplication.kt
@@ -2,8 +2,12 @@ package com.colecto.colecto
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
+@EnableAsync
 class ColectoApplication
 
 fun main(args: Array<String>) {

--- a/server/src/main/kotlin/com/colecto/colecto/repository/PostRepostiory.kt
+++ b/server/src/main/kotlin/com/colecto/colecto/repository/PostRepostiory.kt
@@ -3,4 +3,6 @@ package com.colecto.colecto.repository
 import com.colecto.colecto.model.Post
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface PostRepostiory : JpaRepository<Post, Int>
+interface PostRepostiory : JpaRepository<Post, Int> {
+    fun existsByUrl(url: String): Boolean
+}

--- a/server/src/main/kotlin/com/colecto/colecto/service/RssReader.kt
+++ b/server/src/main/kotlin/com/colecto/colecto/service/RssReader.kt
@@ -1,0 +1,57 @@
+package com.colecto.colecto.service
+
+import com.colecto.colecto.model.Post
+import com.colecto.colecto.model.Rss
+import com.colecto.colecto.repository.PostRepostiory
+import com.colecto.colecto.repository.RssRepostiory
+import jakarta.transaction.Transactional
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+
+@Service
+class RssReader(private val rssRepostiory: RssRepostiory, private val postRepostiory: PostRepostiory, private val transactionTemplate: TransactionTemplate) {
+    private val parser = Parser.xmlParser()
+    private val client = OkHttpClient()
+
+    @Scheduled(fixedDelay = 3000)
+    @Transactional
+    fun sync() {
+        rssRepostiory.findAll().forEach {
+            val posts = readAll(it)
+            saveAll(posts)
+        }
+    }
+
+    private fun readAll(rss: Rss): List<Post> {
+        val request = Request.Builder()
+            .url(rss.url)
+            .build()
+        val response = client.newCall(request).execute()
+        val stream = response.body?.byteStream()!!
+        val document = Jsoup.parse(stream, "utf-8", "", parser)
+        return document.select("item").map {
+            Post(
+                url = it.select("link").text(),
+                title = it.select("title").text(),
+                author = rss.publisher.name,
+                description = it.select("description").text(),
+                publisher = rss.publisher,
+            )
+        }
+    }
+
+    private fun saveAll(posts: List<Post>) {
+        posts.forEach {
+            if (postRepostiory.existsByUrl(it.url)) {
+                return@forEach
+            }
+
+            postRepostiory.save(it)
+        }
+    }
+}

--- a/server/src/test/kotlin/com/colecto/colecto/service/DataTest.kt
+++ b/server/src/test/kotlin/com/colecto/colecto/service/DataTest.kt
@@ -1,0 +1,50 @@
+package com.colecto.colecto.repository
+
+import com.colecto.colecto.model.Publisher
+import com.colecto.colecto.model.Rss
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.lang.Thread.sleep
+
+@SpringBootTest
+class RssReader {
+
+    @Autowired
+    lateinit var rssRepostiory: RssRepostiory
+
+    @Autowired
+    lateinit var publisherRepostiory: PublisherRepostiory
+
+    @Autowired
+    lateinit var postRepostiory: PostRepostiory
+
+    @BeforeEach
+    fun reset() {
+        publisherRepostiory.deleteAll()
+        postRepostiory.deleteAll()
+        rssRepostiory.deleteAll()
+    }
+
+    @Test
+    fun `sycn kakao data`() {
+        assertEquals(0, postRepostiory.findAll().count())
+        val publisher = publisherRepostiory.save(
+            Publisher("kakao", "https://tech.kakao.com/blog/"),
+        )
+
+        rssRepostiory.save(
+            Rss(
+                "https://tech.kakao.com/feed/",
+                publisher,
+            ),
+        )
+
+        sleep(5000)
+
+        assertNotEquals(0, postRepostiory.findAll().count())
+    }
+}


### PR DESCRIPTION
### Background
- RSS통해 블로그 글을 불러올 수 있도록 하기 위한 스케쥴러 구현

### Desc
- 카카오를 테스트로 개발 블로그 글들을 불러올 수 있게 구현
- 3초마다 실행되게 하자, 중복 글이 불러와질 수 있는데 중복 글은 우선 navie하게 중복 체크해서 save하지 말자

### Ticket link
- https://www.notion.so/1-rss-a91f4d2a2e3249f0889746797b401f30
